### PR TITLE
fix: missing tiktoken_bg.wasm

### DIFF
--- a/build/webpack/webpack.renderer.config.ts
+++ b/build/webpack/webpack.renderer.config.ts
@@ -126,6 +126,10 @@ export default createConfig((_env, argv) => {
             from: require.resolve('@opensumi/ide-monaco/worker/editor.worker.bundle.js'),
             to: path.join(outDir, codeWindowName, 'editor.worker.bundle.js'),
           },
+          {
+            from: require.resolve('tiktoken/tiktoken_bg.wasm'),
+            to: path.join(outDir, codeWindowName, 'tiktoken_bg.wasm'),
+          },
         ],
       }),
     ],


### PR DESCRIPTION
```
"/Users/k/Desktop/Exia IDE.app/Contents/Resources/app/out/renderer/code/tiktoken_bg.wasm"
"/Users/k/Desktop/Exia IDE.app/Contents/Resources/app/out/renderer/code/node_modules/tiktoken/tiktoken_bg.wasm"
"/Users/k/Desktop/Exia IDE.app/Contents/Resources/app/out/renderer/node_modules/tiktoken/tiktoken_bg.wasm"
"/Users/k/Desktop/Exia IDE.app/Contents/Resources/app/out/node_modules/tiktoken/tiktoken_bg.wasm"
"/Users/k/Desktop/Exia IDE.app/Contents/Resources/app/node_modules/tiktoken/tiktoken_bg.wasm"
"/Users/k/Desktop/Exia IDE.app/Contents/Resources/node_modules/tiktoken/tiktoken_bg.wasm"
"/Users/k/Desktop/Exia IDE.app/Contents/node_modules/tiktoken/tiktoken_bg.wasm"
"/Users/k/Desktop/Exia IDE.app/node_modules/tiktoken/tiktoken_bg.wasm"
"/Users/k/Desktop/node_modules/tiktoken/tiktoken_bg.wasm"
"/Users/k/node_modules/tiktoken/tiktoken_bg.wasm"
"/Users/node_modules/tiktoken/tiktoken_bg.wasm"
"/node_modules/tiktoken/tiktoken_bg.wasm"
```